### PR TITLE
Enable WSDL file caching

### DIFF
--- a/panopto/session.py
+++ b/panopto/session.py
@@ -1,6 +1,8 @@
+from zeep.cache import SqliteCache
 from zeep.client import Client
 from zeep.exceptions import Fault
 from zeep.helpers import serialize_object
+from zeep.transports import Transport
 
 from panopto.auth import PanoptoAuth
 
@@ -9,14 +11,14 @@ class PanoptoSessionManager(object):
 
     def __init__(self, server, username,
                  instance_name=None, application_key=None,
-                 password=None):
+                 password=None, cache_dir=None):
         self.client = {
-            'session': self._client(server, 'SessionManagement'),
-            'access': self._client(server, 'AccessManagement'),
-            'user': self._client(server, 'UserManagement')
+            'session': self._client(server, 'SessionManagement', cache_dir),
+            'access': self._client(server, 'AccessManagement', cache_dir),
+            'user': self._client(server, 'UserManagement', cache_dir)
         }
         self.auth_info = PanoptoAuth.auth_info(
-                server, username, instance_name, application_key, password)
+            server, username, instance_name, application_key, password)
 
         self.server = server
         self.username = username
@@ -24,10 +26,15 @@ class PanoptoSessionManager(object):
         self.application_key = application_key
         self.password = password
 
-    def _client(self, server, name):
+    def _client(self, server, name, cache_dir):
         url = 'https://{}/Panopto/PublicAPI/4.6/{}.svc?wsdl'.format(
             server, name)
-        return Client(url)
+        if cache_dir:
+            cache=SqliteCache(path=cache_dir)
+            transport = Transport(cache=cache, timeout=1440)
+        else:
+            transport = Transport()
+        return Client(url, transport=transport)
 
     def add_folder(self, name, parent_guid):
         try:

--- a/panopto/session.py
+++ b/panopto/session.py
@@ -30,7 +30,7 @@ class PanoptoSessionManager(object):
         url = 'https://{}/Panopto/PublicAPI/4.6/{}.svc?wsdl'.format(
             server, name)
         if cache_dir:
-            cache=SqliteCache(path=cache_dir)
+            cache = SqliteCache(path=cache_dir)
             transport = Transport(cache=cache, timeout=1440)
         else:
             transport = Transport()


### PR DESCRIPTION
The fetching of the .wsdl files is proving to be intermittently slow. Add the ability to cache these files in a local sqlite database.