### PR TITLE
Panopto Folder Query: variable responses

### DIFF
--- a/panopto/session.py
+++ b/panopto/session.py
@@ -63,7 +63,7 @@ class PanoptoSessionManager(object):
                 if folder['Name'] == name:
                     return folder['Id']
             return ''
-        except Fault:
+        except (Fault, TypeError):
             return ''
 
     def get_session_url(self, session_id):


### PR DESCRIPTION
The get_folder query looks like it can return an empty response or an empty array. Handle these exception cases through, well, exception handling.