### PR TITLE
:arrow_up: zeep 3.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ lxml==4.4.1
 requests-toolbelt==0.9.1
 isodate==0.6.0
 cached-property==1.5.1
-zeep==2.5.0 # pyup: <3.0.0
+zeep==3.4.0
 attrs==19.1.0
 pluggy==0.12.0
 funcsigs==1.0.2


### PR DESCRIPTION
It looks like there were some changes in zeep.settings, but pypanopto
doesn't use this module.
https://python-zeep.readthedocs.io/en/master/changes.html#id3